### PR TITLE
allows you to access individual accessor field values, set bulk via symb...

### DIFF
--- a/lib/hstore_accessor.rb
+++ b/lib/hstore_accessor.rb
@@ -43,7 +43,6 @@ module HstoreAccessor
   module ClassMethods
 
     def hstore_accessor(hstore_attribute, fields)
-
       fields.each do |key, type|
 
         raise InvalidDataTypeError unless VALID_TYPES.include?(type)
@@ -54,7 +53,7 @@ module HstoreAccessor
         end
 
         define_method(key) do
-          value = send(hstore_attribute) && send(hstore_attribute)[key.to_s]
+          value = send(hstore_attribute) && send(hstore_attribute).with_indifferent_access[key.to_s]
           deserialize(type, value)
         end
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -158,6 +158,24 @@ describe HstoreAccessor do
       expect(product.color).to eq "blue"
     end
 
+    it "allows access to bulk set values via string before saving" do
+      product.options = {
+        "color" => "blue",
+        "price" => 120
+      }
+      expect(product.color).to eq "blue"
+      expect(product.price).to eq 120
+    end
+
+    it "allows access to bulk set values via :symbols before saving" do
+      product.options = {
+        color: "blue",
+        price: 120
+      }
+      expect(product.color).to eq "blue"
+      expect(product.price).to eq 120
+    end
+
     it "correctly stores integer values" do
       product.price = 468
       product.save


### PR DESCRIPTION
...ol key before saving

Before, if you set several values at once by using hstore_attribute= but used symbols as the keys when doing that, you could not individually access values afterwards.  This is only a problem before the model is persisted.
