### PR TITLE
when a string 'true' is passed to a boolean field it should be saved as 'true'

### DIFF
--- a/lib/hstore_accessor.rb
+++ b/lib/hstore_accessor.rb
@@ -18,7 +18,7 @@ module HstoreAccessor
     :array    => -> value { (value && value.join(SEPARATOR)) || nil },
     :hash     => -> value { (value && value.to_json) || nil },
     :time     => -> value { value.to_i },
-    :boolean  => -> value { (value == true).to_s },
+    :boolean  => -> value { (value.to_s == 'true').to_s },
     :date     => -> value { (value && value.to_s) || nil }
   }
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -270,6 +270,13 @@ describe HstoreAccessor do
       expect(product.released_at).to eq datestamp
     end
 
+    it "correctly stores boolean values when string 'true' is passed" do
+      product.popular = 'true'
+      product.save
+      product.reload
+      expect(product.popular).to be(true)
+    end
+
     it "setters call the _will_change! method of the store attribute" do
       product.should_receive(:options_will_change!)
       product.color = "green"


### PR DESCRIPTION
Hello DevMynd,

First of all, thank you for this awesome gem. I'm using it in multiple projects.

Earlier today I was working on a simple form that creates a new object in the database when submitted, then I discovered that a few boolean fields in the hstore are always saved as false. I double checked the spelling of the fieldnames and the values and then found out the root cause is that when the form values are passed as strings to the controller, and for those boolean fields the gem is comparing the value directly to true to decide if it is true. 

I think it's probably a good idea to assume "true" string means true, so I made this little change here. 

But furthermore, I'm not sure if you guys want to think about more use cases: like by default if you don't assign a value to a checkbox, when it's checked, the value is actually "on" which should be true as well. Or, for a more generic use, should it be

```
    :boolean  => -> value { (value && true).to_s }
```

so all Ruby true value will be casted to true correctly? 
