### PR TITLE
type cast values as they are set

### DIFF
--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -325,6 +325,40 @@ describe HstoreAccessor do
       product.color = "green"
     end
 
+    describe "type casting" do
+      it "type casts integer values" do
+        product.price = '468'
+        expect(product.price).to eq 468
+      end
+      it "type casts float values" do
+        product.weight = '93.45'
+        expect(product.weight).to eq 93.45
+      end
+      it "type casts time values" do
+        timestamp = Time.now - 10.days
+        product.build_timestamp = timestamp.to_s
+        expect(product.build_timestamp.to_i).to eq timestamp.to_i
+      end
+      it "type casts date values" do
+        datestamp = Date.today - 9.days
+        product.released_at = datestamp.to_s
+        expect(product.released_at).to eq datestamp
+      end
+
+      it "type casts boolean values" do
+        ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.each do |value|
+          product.popular = value
+          expect(product.popular).to be_true
+        end
+        ActiveRecord::ConnectionAdapters::Column::FALSE_VALUES.each do |value|
+          product.popular = value
+          expect(product.popular).to be_false
+        end
+      end
+
+
+    end
+
   end
 
 end


### PR DESCRIPTION
This aligns hstore_accessor managed attributes more closely with regular attributes and solves problems I was having using hstore_accessor with forms. For one, without typecasting, setting boolean attributes from a params hash doesn't work, because the params hash will map booleans to "0" or "1", both of which will serialize as false. This patch doesn't include multiparameter typecasting e.g. date(1i) date(2i), date(3i), but I'll look into it.
