### PR TITLE
Use @> operator to speed up eq queries

### DIFF
--- a/lib/hstore_accessor.rb
+++ b/lib/hstore_accessor.rb
@@ -82,29 +82,30 @@ module HstoreAccessor
         end
 
         query_field = "#{hstore_attribute} -> '#{store_key}'"
+        eq_query_field = "#{hstore_attribute} @> hstore('#{store_key}', ?)"
 
         case data_type
         when :string
-          send(:scope, "with_#{key}", -> value { where("#{query_field} = ?", value.to_s) })
+          send(:scope, "with_#{key}", -> value { where(eq_query_field, value.to_s) })
         when :integer, :float
           send(:scope, "#{key}_lt",  -> value { where("(#{query_field})::#{data_type} < ?", value.to_s) })
           send(:scope, "#{key}_lte", -> value { where("(#{query_field})::#{data_type} <= ?", value.to_s) })
-          send(:scope, "#{key}_eq",  -> value { where("(#{query_field})::#{data_type} = ?", value.to_s) })
+          send(:scope, "#{key}_eq",  -> value { where(eq_query_field, value.to_s) })
           send(:scope, "#{key}_gte", -> value { where("(#{query_field})::#{data_type} >= ?", value.to_s) })
           send(:scope, "#{key}_gt",  -> value { where("(#{query_field})::#{data_type} > ?", value.to_s) })
         when :time
           send(:scope, "#{key}_before", -> value { where("(#{query_field})::integer < ?", value.to_i) })
-          send(:scope, "#{key}_eq",     -> value { where("(#{query_field})::integer = ?", value.to_i) })
+          send(:scope, "#{key}_eq",     -> value { where(eq_query_field, value.to_i.to_s) })
           send(:scope, "#{key}_after",  -> value { where("(#{query_field})::integer > ?", value.to_i) })
         when :date
           send(:scope, "#{key}_before", -> value { where("#{query_field} < ?", value.to_s) })
-          send(:scope, "#{key}_eq",     -> value { where("#{query_field} = ?", value.to_s) })
+          send(:scope, "#{key}_eq",     -> value { where(eq_query_field, value.to_s) })
           send(:scope, "#{key}_after",  -> value { where("#{query_field} > ?", value.to_s) })
         when :boolean
-          send(:scope, "is_#{key}", -> { where("#{query_field} = 'true'") })
-          send(:scope, "not_#{key}", -> { where("#{query_field} = 'false'") })
+          send(:scope, "is_#{key}", -> { where(eq_query_field, 'true') })
+          send(:scope, "not_#{key}", -> { where(eq_query_field, 'false') })
         when :array
-          send(:scope, "#{key}_eq",        -> value { where("#{query_field} = ?", value.join(SEPARATOR)) })
+          send(:scope, "#{key}_eq",        -> value { where(eq_query_field, value.join(SEPARATOR)) })
           send(:scope, "#{key}_contains",  -> value do
             where("string_to_array(#{query_field}, '#{SEPARATOR}') @> string_to_array(?, '#{SEPARATOR}')", Array[value].flatten)
           end)


### PR DESCRIPTION
Using @> would take advantage of GIN or GIST indexes to speed up eq query

```
dev=# explain select * from products where properties @> hstore('list_price', '3');
                                           QUERY PLAN
------------------------------------------------------------------------------------------------
 Bitmap Heap Scan on products  (cost=94.95..8976.68 rows=2841 width=83)
   Recheck Cond: (properties @> '"list_price"=>"3"'::hstore)
   ->  Bitmap Index Scan on index_products_on_properties  (cost=0.00..94.24 rows=2841 width=0)
         Index Cond: (properties @> '"list_price"=>"3"'::hstore)
(4 rows)

dev=# explain select * from products where properties -> 'list_price' = '3';
                            QUERY PLAN
------------------------------------------------------------------
 Seq Scan on products  (cost=0.00..83396.12 rows=14206 width=83)
   Filter: ((properties -> 'list_price'::text) = '3'::text)
(2 rows)
```