### PR TITLE
Remove hard dependency on `pg` gem.

### DIFF
--- a/hstore_accessor.gemspec
+++ b/hstore_accessor.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "pg", ">= 0.14.1"
   spec.add_dependency "activesupport", ">= 3.2.0"
 
   spec.add_development_dependency "activerecord", ">= 4.0.0"


### PR DESCRIPTION
Makes this gem incompatible with JRuby. Not required in any case - postgres is 100% required to even use HStore in the first place.
