### PR TITLE
Correctly interpret booleans set directly in hstore hash

### DIFF
--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -24,7 +24,7 @@ module HstoreAccessor
       integer:  -> value { value.to_i },
       float:    -> value { value.to_f },
       time:     -> value { Time.at(value.to_i) },
-      boolean:  -> value { value == "true" },
+      boolean:  -> value { ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES.include?(value) },
       date:     -> value { (value && Date.parse(value)) || nil },
       decimal:  -> value { BigDecimal.new(value) }
     }

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -104,6 +104,26 @@ describe HstoreAccessor do
       expect(product.popular?).to be_false
     end
 
+    it "return true for boolean field set via hash using real boolean" do
+      product.options = { 'popular' => true }
+      expect(product.popular?).to be_true
+    end
+
+    it "return false for boolean field set via hash using real boolean" do
+      product.options = { 'popular' => false }
+      expect(product.popular?).to be_false
+    end
+
+    it "return true for boolean field set via hash using string" do
+      product.options = { 'popular' => 'true' }
+      expect(product.popular?).to be_true
+    end
+
+    it "return false for boolean field set via hash using string" do
+      product.options = { 'popular' => 'false' }
+      expect(product.popular?).to be_false
+    end
+
   end
 
   describe "scopes" do


### PR DESCRIPTION
When using the generated accessor methods to set a boolean values, everything is fine because the accessor sets it using a string.  However, if you set a boolean using true by directly accessing the hstore hash, a subsequent call to the generated accessor will be incorrect.

Example(Using Product class from specs):

``` ruby
p = Product.new
p.options['popular'] = true
p.popular?
```

The last line will return false.  This is due to the deserializer directly comparing the boolean value against the string "true".

This patch changes the code to use `ActiveRecord::ConnectionAdapters::Column::TRUE_VALUES` to accept any true value or string representation of it.
