### PR TITLE
Added default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Reading these fields works as well.
 
 ```ruby
 p.color #=> "green"
-p.tags #=> ["housewares", "kitchen"] 
+p.tags #=> ["housewares", "kitchen"]
 ```
 
 In order to reduce the storage overhead of hstore keys (especially when
@@ -88,7 +88,16 @@ p.changed?        #=> true
 p.color_changed?  #=> true
 p.color_was       #=> "green"
 p.color_changes   #=> ["green", "blue"]
-``` 
+```
+
+Default values are available using a `default` option, e.g.
+
+```ruby
+hstore_accessor :options,
+  category: { data_type: :array, default: -> { [] }
+```
+
+The value of a `default` option is always a `Proc`. It is `call`ed when calling the getter and counts as transient, e.g. a field with a `nil` value and a `default` is not `present?`.
 
 ### Scopes
 

--- a/lib/hstore_accessor/macro.rb
+++ b/lib/hstore_accessor/macro.rb
@@ -13,10 +13,13 @@ module HstoreAccessor
 
           data_type = type
           store_key = key
+          default_value = nil
+
           if type.is_a?(Hash)
             type = type.with_indifferent_access
             data_type = type[:data_type]
             store_key = type[:store_key]
+            default_value = type[:default]
           end
 
           data_type = data_type.to_sym
@@ -31,8 +34,16 @@ module HstoreAccessor
           end
 
           field_methods.send(:define_method, key) do
+
             value = send(hstore_attribute) && send(hstore_attribute).with_indifferent_access[store_key.to_s]
-            deserialize(data_type, value)
+            data = deserialize(data_type, value)
+
+            if data.nil? && default_value
+              default_value.call
+            else
+              data
+            end
+
           end
 
           field_methods.send(:define_method, "#{key}?") do


### PR DESCRIPTION
Solves #7 and could easily be extend to solve #20 (making #30 obsolete perhaps, didn't look too close).

Currently I treat the default value as transient / sth. that is evaluated once (and not cached) in the getter. So before merging we should agree on whether
1. the value should get cached (currently: not)
2. `present?` etc. should return always true for default value (currently: not)
