### PR TITLE
Improved dirty tracking

### DIFF
--- a/lib/hstore_accessor/macro.rb
+++ b/lib/hstore_accessor/macro.rb
@@ -24,9 +24,12 @@ module HstoreAccessor
           raise Serialization::InvalidDataTypeError unless Serialization::VALID_TYPES.include?(data_type)
 
           field_methods.send(:define_method, "#{key}=") do |value|
-            serialized_value = serialize(data_type, TypeHelpers.cast(data_type, value))
-            send(:attribute_will_change!, key)
-            send("#{hstore_attribute}_will_change!")
+            casted_value = TypeHelpers.cast(data_type, value)
+            serialized_value = serialize(data_type, casted_value)
+            unless send(key) == casted_value
+              send(:attribute_will_change!, key)
+              send("#{hstore_attribute}_will_change!")
+            end
             send("#{hstore_attribute}=", (send(hstore_attribute) || {}).merge(store_key.to_s => serialized_value))
           end
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -487,6 +487,17 @@ describe HstoreAccessor do
       expect(product.color_changed?).to be true
       product.save
       expect(product.color_changed?).to be false
+      product.color = "ORANGE"
+      expect(product.color_changed?).to be false
+
+      expect(product.price_changed?).to be false
+      product.price = 100
+      expect(product.price_changed?).to be true
+      product.save
+      expect(product.price_changed?).to be false
+      product.price = "100"
+      expect(product.price).to be 100
+      expect(product.price_changed?).to be false
     end
 
     it "<attr>_was should return the expected value" do


### PR DESCRIPTION
This builds upon the fix in #34, and only marks an attribute as dirty if it actually changes. I don't see any reason why the library shouldn't work this way, but this could be considered an enhancement, whereas #34 is clearly a bug, so I decided to split them up.
