### PR TITLE
Ensured contains queries on array fields can handle more than 2 strings 

### DIFF
--- a/lib/hstore_accessor/macro.rb
+++ b/lib/hstore_accessor/macro.rb
@@ -76,7 +76,7 @@ module HstoreAccessor
           when :array
             send(:scope, "#{key}_eq",        -> value { where("#{query_field} = ?", value.join(Serialization::SEPARATOR)) })
             send(:scope, "#{key}_contains",  -> value do
-              where("string_to_array(#{query_field}, '#{Serialization::SEPARATOR}') @> string_to_array(?, '#{Serialization::SEPARATOR}')", Array[value].flatten)
+              where("string_to_array(#{query_field}, '#{Serialization::SEPARATOR}') @> string_to_array(?, '#{Serialization::SEPARATOR}')", Array[value].flatten.join(Serialization::SEPARATOR))
             end)
           end
         end

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -239,6 +239,8 @@ describe HstoreAccessor do
       it "contains" do
         expect(Product.tags_contains("tag2").to_a).to eq [product_a, product_b]
         expect(Product.tags_contains(["tag2", "tag3"]).to_a).to eq [product_a, product_b]
+        expect(Product.tags_contains(["tag1", "tag2", "tag3"]).to_a).to eq [product_a]
+        expect(Product.tags_contains(["tag1", "tag2", "tag3", "tag4"]).to_a).to eq []
       end
 
     end


### PR DESCRIPTION
Ensured contains queries on array fields can handle more than 2 strings as mentioned in issue #36. 
