### PR TITLE
Road to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,12 @@ post](http://www.devmynd.com/blog/2013-3-single-table-inheritance-hstore-lovely-
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new Pull Request
+
+## Changelog
+
+`2.0.0` - Changed the way that hashes and arrays are serialized into the
+Hstore column. We are using YAML now. This allows for more complex
+data structures within those types. It also allows us to keep Rubyisms like
+symbols, integers, hashes, arrays and even custom objects in those Hstore
+attributes. In turn, this makes it difficult to query specific array values
+in the column's attributes. So, the `_contains` scope has been eliminated.

--- a/README.md
+++ b/README.md
@@ -129,9 +129,7 @@ Product.built_at_after(Time.now - 4.days) # built after the given time
 For `array` types, two scopes are created:
 
 ```ruby
-Product.tags_eq(%w(housewares kitchen))       # tags equaling
-Product.tags_contains("kitchen")              # tags containing a single value
-Product.tags_contains(%w(housewares kitchen)) # tags containing a number of values
+Product.tags_eq(%w(housewares kitchen)) # tags equaling
 ```
 
 #### Boolean Fields

--- a/hstore_accessor.gemspec
+++ b/hstore_accessor.gemspec
@@ -6,8 +6,8 @@ require "hstore_accessor/version"
 Gem::Specification.new do |spec|
   spec.name          = "hstore_accessor"
   spec.version       = HstoreAccessor::VERSION
-  spec.authors       = ["Joe Hirn", "Cory Stephenson", "JC Grubbs"]
-  spec.email         = ["joe@devmynd.com", "cory@devmynd.com", "jc@devmynd.com"]
+  spec.authors       = ["Joe Hirn", "Cory Stephenson", "JC Grubbs", "Tony Coconate"]
+  spec.email         = ["joe@devmynd.com", "cory@devmynd.com", "jc@devmynd.com", "me@tonycoconate.com"]
   spec.description   = %q{Adds typed hstore backed fields to an ActiveRecord model.}
   spec.summary       = %q{Adds typed hstore backed fields to an ActiveRecord model.}
   spec.homepage      = "http://github.com/devmynd/hstore_accessor"
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "database_cleaner"
+
+  spec.post_install_message = "Please note that there are breaking changes in version 2.0.0! Refer to the changelog here...\nhttps://github.com/devmynd/hstore_accessor"
 end

--- a/lib/hstore_accessor/macro.rb
+++ b/lib/hstore_accessor/macro.rb
@@ -78,8 +78,7 @@ module HstoreAccessor
             send(:scope, "is_#{key}", -> { where("#{query_field} = 'true'") })
             send(:scope, "not_#{key}", -> { where("#{query_field} = 'false'") })
           when :array
-            send(:scope, "#{key}_eq", -> value { where("#{query_field} = ?", value.join(Serialization::SEPARATOR)) })
-            send(:scope, "#{key}_contains", -> value { where("string_to_array(#{query_field}, '#{Serialization::SEPARATOR}') @> string_to_array(?, '#{Serialization::SEPARATOR}')", Array[value].flatten.join(Serialization::SEPARATOR)) })
+            send(:scope, "#{key}_eq", -> value { where("#{query_field} = ?", YAML.dump(Array.wrap(value))) })
           end
         end
 

--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -8,29 +8,27 @@ module HstoreAccessor
     DEFAULT_DESERIALIZER = DEFAULT_SERIALIZER
 
     SERIALIZERS = {
-      array: -> value { (value && YAML.dump(Array.wrap(value))) || nil },
+      array: -> value { value && YAML.dump(Array.wrap(value)) },
       boolean: -> value { (value.to_s == "true").to_s },
-      date: -> value { (value && value.to_s) || nil },
+      date: -> value { value && value.to_s },
       hash: lambda do |value|
         if value
           raise InvalidDataTypeError, "Cannot serialize a non-hash value into the hash typed attribute" unless value.is_a?(Hash)
           YAML.dump(value)
-        else
-          nil
         end
       end,
-      time: -> value { (value && value.to_i) || nil }
+      time: -> value { value && value.to_i }
     }
 
     DESERIALIZERS = {
-      array: -> value { (value && YAML.load(value)) || nil },
+      array: -> value { value && YAML.load(value) },
       boolean: -> value { TypeHelpers.cast(:boolean, value) },
-      date: -> value { (value && Date.parse(value)) || nil },
-      decimal: -> value { (value && BigDecimal.new(value)) || nil },
-      float: -> value { (value && value.to_f) || nil },
-      hash: -> value { (value && YAML.load(value)) || nil },
-      integer: -> value { (value && value.to_i) || nil },
-      time: -> value { (value && Time.at(value.to_i)) || nil }
+      date: -> value { value && Date.parse(value) },
+      decimal: -> value { value && BigDecimal.new(value) },
+      float: -> value { value && value.to_f },
+      hash: -> value { value && YAML.load(value) },
+      integer: -> value { value && value.to_i },
+      time: -> value { value && Time.at(value.to_i) }
     }
 
     def serialize(type, value, serializer=nil)

--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -9,6 +9,8 @@ module HstoreAccessor
 
     SERIALIZERS = {
       array: -> value { (value && YAML.dump(Array.wrap(value))) || nil },
+      boolean: -> value { (value.to_s == "true").to_s },
+      date: -> value { (value && value.to_s) || nil },
       hash: lambda do |value|
         if value
           raise InvalidDataTypeError, "Cannot serialize a non-hash value into the hash typed attribute" unless value.is_a?(Hash)
@@ -17,20 +19,18 @@ module HstoreAccessor
           nil
         end
       end,
-      time: -> value { value.to_i },
-      boolean: -> value { (value.to_s == "true").to_s },
-      date: -> value { (value && value.to_s) || nil }
+      time: -> value { (value && value.to_i) || nil }
     }
 
     DESERIALIZERS = {
       array: -> value { (value && YAML.load(value)) || nil },
-      hash: -> value { (value && YAML.load(value)) || nil },
-      integer: -> value { value.to_i },
-      float: -> value { value.to_f },
-      time: -> value { Time.at(value.to_i) },
       boolean: -> value { TypeHelpers.cast(:boolean, value) },
       date: -> value { (value && Date.parse(value)) || nil },
-      decimal: -> value { BigDecimal.new(value) }
+      decimal: -> value { (value && BigDecimal.new(value)) || nil },
+      float: -> value { (value && value.to_f) || nil },
+      hash: -> value { (value && YAML.load(value)) || nil },
+      integer: -> value { (value && value.to_i) || nil },
+      time: -> value { (value && Time.at(value.to_i)) || nil }
     }
 
     def serialize(type, value, serializer=nil)

--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -10,16 +10,23 @@ module HstoreAccessor
     DEFAULT_DESERIALIZER = DEFAULT_SERIALIZER
 
     SERIALIZERS = {
-      array: -> value { (value && value.join(SEPARATOR)) || nil },
-      hash: -> value { (value && value.to_json) || nil },
+      array: -> value { (value && YAML.dump(Array.wrap(value))) || nil },
+      hash: lambda do |value|
+        if value
+          raise InvalidDataTypeError, "Cannot serialize a non-hash value into the hash typed attribute" unless value.is_a?(Hash)
+          YAML.dump(value)
+        else
+          nil
+        end
+      end,
       time: -> value { value.to_i },
       boolean: -> value { (value.to_s == "true").to_s },
       date: -> value { (value && value.to_s) || nil }
     }
 
     DESERIALIZERS = {
-      array: -> value { (value && value.split(SEPARATOR)) || nil },
-      hash: -> value { (value && JSON.parse(value)) || nil },
+      array: -> value { (value && YAML.load(value)) || nil },
+      hash: -> value { (value && YAML.load(value)) || nil },
       integer: -> value { value.to_i },
       float: -> value { value.to_f },
       time: -> value { Time.at(value.to_i) },

--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -4,8 +4,6 @@ module HstoreAccessor
 
     VALID_TYPES = [:string, :integer, :float, :time, :boolean, :array, :hash, :date, :decimal]
 
-    SEPARATOR = "||;||"
-
     DEFAULT_SERIALIZER = ->(value) { value.to_s }
     DEFAULT_DESERIALIZER = DEFAULT_SERIALIZER
 

--- a/lib/hstore_accessor/version.rb
+++ b/lib/hstore_accessor/version.rb
@@ -1,3 +1,3 @@
 module HstoreAccessor
-  VERSION = "0.6.1"
+  VERSION = "2.0.0"
 end

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -300,6 +300,13 @@ describe HstoreAccessor do
     end
 
     context "array values" do
+      it "correctly stores nothing" do
+        product.tags = nil
+        product.save
+        product.reload
+        expect(product.tags).to be_nil
+      end
+
       it "correctly stores strings" do
         product.tags = ["household", "living room", "kitchen"]
         product.save
@@ -330,6 +337,13 @@ describe HstoreAccessor do
     end
 
     context "hash values" do
+      it "correctly stores nothing" do
+        product.reviews = nil
+        product.save
+        product.reload
+        expect(product.reviews).to be_nil
+      end
+
       it "correctly stores stringy-keyed hash values" do
         product.reviews = { "user_123" => "4 stars", "user_994" => "3 stars" }
         product.save

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -321,7 +321,7 @@ describe HstoreAccessor do
         expect(product.tags).to eq [1, 2, "3"]
       end
 
-      it "correctly stores hashes with indifferent access" do
+      it "correctly stores hashes" do
         product.tags = [{ foo: "bar" }, { "baz" => 123 }]
         product.save
         product.reload

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -344,10 +344,30 @@ describe HstoreAccessor do
         expect(product.reviews).to eq("user_123" => [1, 2], "user_994" => "stringy", foo: :bar, baz: 1, zoo: "zaz", hashy: { test: 1 })
       end
 
+      it "correctly stores an object" do
+        class Stuff
+          attr_accessor :thing
+        end
+
+        stuff = Stuff.new
+        stuff.thing = "1"
+
+        product.reviews = { "stuff" => stuff }
+        product.save
+        product.reload
+
+        expect(product.reviews["stuff"].thing).to eq(stuff.thing)
+
+        Object.send(:remove_const, :Stuff)
+        product.reload
+
+        expect { product.reviews }.to raise_error
+      end
+
       it "raises an exception when trying to store a non-hash value" do
-        expect {
+        expect do
           product.reviews = "hello"
-        }.to raise_error(HstoreAccessor::Serialization::InvalidDataTypeError)
+        end.to raise_error(HstoreAccessor::Serialization::InvalidDataTypeError)
       end
     end
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -216,13 +216,6 @@ describe HstoreAccessor do
       it "equality" do
         expect(Product.tags_eq(%w(tag1 tag2 tag3)).to_a).to eq [product_a]
       end
-
-      it "contains" do
-        expect(Product.tags_contains("tag2").to_a).to eq [product_a, product_b]
-        expect(Product.tags_contains(%w(tag2 tag3)).to_a).to eq [product_a, product_b]
-        expect(Product.tags_contains(%w(tag1 tag2 tag3)).to_a).to eq [product_a]
-        expect(Product.tags_contains(%w(tag1 tag2 tag3 tag4)).to_a).to eq []
-      end
     end
 
     context "for time fields support" do
@@ -306,18 +299,56 @@ describe HstoreAccessor do
       expect(product.weight).to eq 93.45
     end
 
-    it "correctly stores array values" do
-      product.tags = ["household", "living room", "kitchen"]
-      product.save
-      product.reload
-      expect(product.tags).to eq ["household", "living room", "kitchen"]
+    context "array values" do
+      it "correctly stores strings" do
+        product.tags = ["household", "living room", "kitchen"]
+        product.save
+        product.reload
+        expect(product.tags).to eq ["household", "living room", "kitchen"]
+      end
+
+      it "correctly stores integers" do
+        product.tags = [1, 2, "3"]
+        product.save
+        product.reload
+        expect(product.tags).to eq [1, 2, "3"]
+      end
+
+      it "correctly stores hashes with indifferent access" do
+        product.tags = [{ foo: "bar" }, { "baz" => 123 }]
+        product.save
+        product.reload
+        expect(product.tags).to eq [{ foo: "bar" }, { "baz" => 123 }]
+      end
+
+      it "correctly stores non-arrays as array wrapped objects" do
+        product.tags = "bar"
+        product.save
+        product.reload
+        expect(product.tags).to eq ["bar"]
+      end
     end
 
-    it "correctly stores hash values" do
-      product.reviews = { "user_123" => "4 stars", "user_994" => "3 stars" }
-      product.save
-      product.reload
-      expect(product.reviews).to eq("user_123" => "4 stars", "user_994" => "3 stars")
+    context "hash values" do
+      it "correctly stores stringy-keyed hash values" do
+        product.reviews = { "user_123" => "4 stars", "user_994" => "3 stars" }
+        product.save
+        product.reload
+        expect(product.reviews).to eq("user_123" => "4 stars", "user_994" => "3 stars")
+      end
+
+      it "correctly stores a variety of hash values" do
+        product.reviews = { "user_123" => [1, 2], "user_994" => "stringy", foo: :bar, baz: 1, zoo: "zaz", hashy: { test: 1 } }
+        product.save
+        product.reload
+        expect(product.reviews).to eq("user_123" => [1, 2], "user_994" => "stringy", foo: :bar, baz: 1, zoo: "zaz", hashy: { test: 1 })
+      end
+
+      it "raises an exception when trying to store a non-hash value" do
+        expect {
+          product.reviews = "hello"
+        }.to raise_error(HstoreAccessor::Serialization::InvalidDataTypeError)
+      end
     end
 
     it "correctly stores time values" do


### PR DESCRIPTION
This changes the internal representation of arrays and hashes in the Hstore column to be YAML. It alleviates the need for a separator. Check the README.md for more information and a breakdown of changes.