### PR TITLE
deserialze time with zone to provide consistent accessor interface

### DIFF
--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -29,7 +29,7 @@ module HstoreAccessor
       float: -> value { value && value.to_f },
       hash: -> value { value && YAML.load(value) },
       integer: -> value { value && value.to_i },
-      datetime: -> value { value && Time.at(value.to_i) }
+      datetime: -> value { value && Time.at(value.to_i).in_time_zone }
     }
     DESERIALIZERS.default = DEFAULT_DESERIALIZER
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -499,8 +499,9 @@ describe HstoreAccessor do
         product.build_timestamp = timestamp
         product.save
         product.reload
-        Time.zone = other_zone
-        expect(product.build_timestamp.utc_offset).to eq other_zone.utc_offset
+        Time.use_zone(other_zone) do
+          expect(product.build_timestamp.utc_offset).to eq other_zone.utc_offset
+        end
       end
     end
 

--- a/spec/hstore_accessor_spec.rb
+++ b/spec/hstore_accessor_spec.rb
@@ -478,12 +478,30 @@ describe HstoreAccessor do
       end
     end
 
-    it "correctly stores time values" do
-      timestamp = Time.now - 10.days
-      product.build_timestamp = timestamp
-      product.save
-      product.reload
-      expect(product.build_timestamp.to_i).to eq timestamp.to_i
+    context "time values" do
+      let(:other_zone){(ActiveSupport::TimeZone.all - Array(Time.zone)).sample}
+      it "correctly stores value" do
+        timestamp = Time.now - 10.days
+        product.build_timestamp = timestamp
+        product.save
+        product.reload
+        expect(product.build_timestamp.to_i).to eq timestamp.to_i
+      end
+
+      it "stores the value in utc" do
+        timestamp = Time.now.in_time_zone(other_zone) - 10.days
+        product.build_timestamp = timestamp
+        expect(product.options['build_timestamp'].to_i).to eq timestamp.utc.to_i
+      end
+
+      it "returns the time value in the current time zone" do
+        timestamp = Time.now - 10.days
+        product.build_timestamp = timestamp
+        product.save
+        product.reload
+        Time.zone = other_zone
+        expect(product.build_timestamp.utc_offset).to eq other_zone.utc_offset
+      end
     end
 
     it "correctly stores date values" do


### PR DESCRIPTION
My understanding is that an Active Record date_time accessors are time zone aware, returning the object configured with the current time zone (e.g. not the system time). If I'm wrong there, just let me know.

Migrating to this gem with existing data (e.g replacing field foo_at that was an Active Record date_time type field with an hstore_accessor attribute with data_type: :time resulted in unexpected behavior, where the returned object is now initialized with the zone of the system clock.

Before migration to hstore

some_model.foo_at.iso8601
=> 2015-05-11T21:28:00Z
After migration to hstore

some_model.foo_at.iso8601
=> 2015-05-11T16:28:00-05:00
The change in this PR fixes this, such that the ActiveSupport timezone is respected.

If you think this is the right direction, I'd love your thoughts about the robustness of this change, and how to best integrate that with the test suite.