### PR TITLE
Configure shoulda-matchers

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ require "shoulda-matchers"
 
 DatabaseCleaner.strategy = :truncation
 
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :active_record
+  end
+end
+
 RSpec.configure do |config|
   config.mock_with :rspec
   config.order = :random


### PR DESCRIPTION
Since v3.0.0, `shoulda-matchers` no longer detects the test framework
in use or mixes itself into that framework automatically.

It now requires a configuration block to be included in `spec_helper`
to specify the frameworks and libraries in use.

See https://github.com/thoughtbot/shoulda-matchers/blob/master/NEWS.md#backward-incompatible-changes
