### PR TITLE
Keep behaviour consistent for decimal fields between Ruby 2.3 and 2.4

### DIFF
--- a/lib/hstore_accessor/serialization.rb
+++ b/lib/hstore_accessor/serialization.rb
@@ -25,7 +25,7 @@ module HstoreAccessor
     DESERIALIZERS = {
       boolean: -> value { TypeHelpers.cast(:boolean, value) },
       date: -> value { value && Date.parse(value) },
-      decimal: -> value { value && BigDecimal.new(value) },
+      decimal: -> value { value && (value == '' ? BigDecimal.new(0) : BigDecimal.new(value)) },
       float: -> value { value && value.to_f },
       integer: -> value { value && value.to_i },
       datetime: -> value { value && Time.at(value.to_i).in_time_zone }


### PR DESCRIPTION
In Ruby 2.4 behaviour of `BigDecimal()` has been changed so that it raises an `ArgumentError` for an empty string, while in 2.3 it was returning 0.

This patch keeps the behaviour consistent for this gem across the two versions.